### PR TITLE
changed get_subject_sessions to work with multiple protocols

### DIFF
--- a/ibc_public/utils_data.py
+++ b/ibc_public/utils_data.py
@@ -41,17 +41,18 @@ for i in range(len(CONTRASTS)):
                                      CONTRASTS['right label'][i]]
 
 
-def get_subject_session(protocol):
+def get_subject_session(*protocols):
     """ utility to get all (subject, session) for a given protocol"""
     import pandas as pd
     df = pd.read_csv(os.path.join(
         _package_directory, '../ibc_data', 'sessions.csv'), index_col=0)
     subject_session = []
-    for session in df.columns:
-        if (df[session] == protocol).any():
-            subjects = df[session][df[session] == protocol].keys()
-            for subject in subjects:
-                subject_session.append((subject,  session))
+    for protocol in protocols:
+        for session in df.columns:
+            if (df[session] == protocol).any():
+                subjects = df[session][df[session] == protocol].keys()
+                for subject in subjects:
+                    subject_session.append((subject,  session))
     return subject_session
 
 

--- a/ibc_public/utils_data.py
+++ b/ibc_public/utils_data.py
@@ -41,7 +41,7 @@ for i in range(len(CONTRASTS)):
                                      CONTRASTS['right label'][i]]
 
 
-def get_subject_session(*protocols):
+def get_subject_session(protocols: list) -> list:
     """ utility to get all (subject, session) for a given protocol"""
     import pandas as pd
     df = pd.read_csv(os.path.join(

--- a/ibc_public/utils_data.py
+++ b/ibc_public/utils_data.py
@@ -42,7 +42,24 @@ for i in range(len(CONTRASTS)):
 
 
 def get_subject_session(protocols: list) -> list:
-    """ utility to get all (subject, session) for a given protocol"""
+    """
+    Utility to get all (subject, session) for a given protocol or set
+    of protocols
+
+    Parameters
+    ----------
+
+    protocols: list
+               List whose elements are the names of the protocols the user
+               wants to retrieve
+
+    Returns
+    -------
+
+    subject_session: list of tuples
+                     Each element correspondes to a (subject, session) pair
+                     for the requested protocols
+    """
     import pandas as pd
     df = pd.read_csv(os.path.join(
         _package_directory, '../ibc_data', 'sessions.csv'), index_col=0)

--- a/ibc_public/utils_data.py
+++ b/ibc_public/utils_data.py
@@ -41,7 +41,7 @@ for i in range(len(CONTRASTS)):
                                      CONTRASTS['right label'][i]]
 
 
-def get_subject_session(protocols: list) -> list:
+def get_subject_session(protocols):
     """
     Utility to get all (subject, session) for a given protocol or set
     of protocols


### PR DESCRIPTION
A simple modification to the get_all_sessions function to make it able to work passing more than one protocol. The behavior when passing one protocol is unchanged. I think this might be useful for common uses of the function (i.e., fetching sessions for arbitrary sets of protocols for comparison, analysis, etc.)