### PR TITLE
moving qmri estimation scripts to public repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ ibc_public/__pycache__/
 *.pyc
 ibc_data/all_contrasts_sparse.tsv
 processing/pyscript.m
-
+scripts/cache_dir
+scripts/pyscript*.m

--- a/ibc_public/utils_relaxo.py
+++ b/ibc_public/utils_relaxo.py
@@ -28,6 +28,10 @@ from nilearn.image.image import new_img_like
 
 
 def closing(image, iterations):
+    """
+    Wrapper for scipy's binary_closing function to close
+    a NIFTI image with n iterations
+    """
     image_data = image.get_fdata()
     image_affine = image.affine
     closing_test = ndimage.binary_closing(image_data, iterations=iterations).astype(int)
@@ -37,6 +41,10 @@ def closing(image, iterations):
     return closing_test
 
 def to_T2space(t2_img, t1_img, output_dir):
+    """
+    Wrapper for pypreprocess's coregister function,
+    used here to coregister T1 image to T2 image 
+    """
     data = SubjectData()
     data.anat = t1_img
     data.func = [t2_img]
@@ -48,6 +56,10 @@ def to_T2space(t2_img, t1_img, output_dir):
     return coreged
 
 def to_MNI(image, data = SubjectData(), func=None):
+    """
+    Wrapper for pypreprocess's normalize function,
+    to transform images from subject space to MNI-152 space
+    """
     data.anat = image
     data.func = func
     data.output_dir = '.'
@@ -60,6 +72,10 @@ def to_MNI(image, data = SubjectData(), func=None):
     return normalized
 
 def segment(image, normalize):
+    """
+    Wrapper for pypreprocess's segment function,
+    to segment images into grey matter, white matter and csf
+    """
     data = SubjectData()
     data.anat = image
     segmented = _do_subject_segment(data, caching=False,
@@ -68,7 +84,11 @@ def segment(image, normalize):
 
 def plot_thresholded_qmap(img, coords, output_folder, brain=None, mask=None,
                         thresh=99, map="map", interactive=False):
-
+    """
+    Plot the final estimated t1 or t2-maps
+    and threshold voxel intensity at some percentile 
+    or an arbitrary intensity
+    """
     # flatten image data for calculating threshold
     img_arr = load(img).get_data().astype(float)
     img_arr_flat = img_arr.reshape((-1, img_arr.shape[-1])).flatten()
@@ -128,13 +148,18 @@ def plot_thresholded_qmap(img, coords, output_folder, brain=None, mask=None,
     normal_view.savefig(fig_name)
     normal_view.close()
 
-# only one of do_normalise_before and do_normalise_after should be True
-# both can be False
+
+
 def t2_pipeline(do_coreg=True, do_normalise_before=False,
                 do_segment=True, do_normalise_after=False, do_plot=True,
                 keep_tmp=True, sub_name='sub-11', sess_num='ses-17',
                 root_path='/neurospin/ibc'):
-
+    """
+    Preprocess qMRI t2 images and then run estimation to generate t2-maps,
+    more details in scripts/qmri_README.md,
+    only one of do_normalise_before and do_normalise_after should be True,
+    both can be False
+    """
     DATA_LOC = join(root_path, 'sourcedata', sub_name, sess_num)
     SAVE_TO = join(root_path, 'derivatives', sub_name, sess_num)
 
@@ -368,14 +393,18 @@ def t2_pipeline(do_coreg=True, do_normalise_before=False,
 
 
 
-# only one of do_normalise_before and do_normalise_after should be True
-# both can be False
+
 def t1_pipeline(do_normalise_before=False,
                 do_segment=True, do_normalise_after=False,
                 do_plot=True,  keep_tmp=True ,
                 sub_name='sub-11', sess_num='ses-17', 
                 root_path='/neurospin/ibc'):
-
+    """
+    Preprocess qMRI t1 images and then run estimation to generate t1-maps,
+    more details in scripts/qmri_README.md,
+    only one of do_normalise_before and do_normalise_after should be True,
+    both can be False
+    """
     DATA_LOC = join(root_path, 'sourcedata', sub_name, sess_num)
     SAVE_TO = join(root_path, 'derivatives', sub_name, sess_num)
 

--- a/ibc_public/utils_relaxo.py
+++ b/ibc_public/utils_relaxo.py
@@ -1,0 +1,589 @@
+"""
+This module contains pipelines and functions 
+for generating qMRI t1 and t2-maps.
+
+Author: Himanshu Aggarwal (himanshu.aggarwal@inria.fr), 2021-22
+"""
+
+import warnings
+warnings.filterwarnings("ignore")
+
+from os import (listdir, system, makedirs, sep)
+from os.path import join, exists
+import time
+import shutil
+from pypreprocess.nipype_preproc_spm_utils import (_do_subject_coregister,
+                    _do_subject_normalize,_do_subject_segment, SubjectData)
+
+from nilearn.masking import (compute_brain_mask, compute_background_mask,
+                        compute_epi_mask,intersect_masks)
+from nilearn.image import (math_img, resample_to_img, mean_img)
+from nilearn import plotting as nilplot
+from matplotlib.pyplot import (hist, savefig, title, close)
+from matplotlib import cm
+from nibabel import load
+from numpy import (nanpercentile, nanmin)
+from scipy import ndimage
+from nilearn.image.image import new_img_like
+
+
+def closing(image, iterations):
+    image_data = image.get_fdata()
+    image_affine = image.affine
+    closing_test = ndimage.binary_closing(image_data, iterations=iterations).astype(int)
+
+    closing_test = new_img_like(image, closing_test, image_affine)
+
+    return closing_test
+
+def to_T2space(t2_img, t1_img, output_dir):
+    data = SubjectData()
+    data.anat = t1_img
+    data.func = [t2_img]
+    data.output_dir = output_dir
+    coreged = _do_subject_coregister(data,
+                                    caching=False,
+                                    hardlink_output=False,
+                                    coreg_anat_to_func=True)
+    return coreged
+
+def to_MNI(image, data = SubjectData(), func=None):
+    data.anat = image
+    data.func = func
+    data.output_dir = '.'
+
+    normalized = _do_subject_normalize(data,
+                                    caching=False,
+                                    hardlink_output=False,
+                                    func_write_voxel_sizes=[1, 1, 1],
+                                    anat_write_voxel_sizes=[1, 1, 1])
+    return normalized
+
+def segment(image, normalize):
+    data = SubjectData()
+    data.anat = image
+    segmented = _do_subject_segment(data, caching=False,
+                    normalize=normalize, hardlink_output=False)
+    return segmented
+
+def plot_thresholded_qmap(img, coords, output_folder, brain=None, mask=None,
+                        thresh=99, map="map", interactive=False):
+
+    # flatten image data for calculating threshold
+    img_arr = load(img).get_data().astype(float)
+    img_arr_flat = img_arr.reshape((-1, img_arr.shape[-1])).flatten()
+
+    # t1 map has negatives - keeping only positive values
+    if nanmin(img_arr_flat) < 0:
+        # too many zeros result in threshold at 0 - even at 99%
+        # calculating threshold after removing -ves and 0s
+        img_arr_flat = img_arr_flat[img_arr_flat > 0]
+
+    # calculating threshold
+    # if given threshold is specified as percentile
+    if type(thresh) is str:
+        threshold = nanpercentile(img_arr_flat, float(thresh))
+        titl = 'Voxel distribution ranged between [0, {}] (at {} percentile)'.format(threshold, thresh)
+    # if given threshold is specified as voxel value
+    else:
+        threshold = float(thresh)
+        titl = 'Voxel distribution ranged between [0, {}]'.format(thresh)
+    # removing voxels higher than threshold
+    img_arr_flat_threshold = img_arr_flat[img_arr_flat <= threshold]
+    print("{} - voxels ranging [0, {}] plotted".format(map, threshold, thresh))
+
+    # plot distribution w/o thresholding in blue
+    # hist(img_arr_flat)
+    # show()
+
+    # plot voxel distribution upto threshold
+    hist(img_arr_flat_threshold)
+    title(titl)
+    fig_name = join(output_folder, '{}_vox_dist.pdf'.format(map))
+    savefig(fig_name, bbox_inches='tight')
+    close()
+
+    # plot interactive thresholded t2 map image
+    # this is buggy
+    if interactive:
+        html_view = nilplot.view_img(img,
+                                    brain,
+                                    cmap=cm.gray,
+                                    symmetric_cmap=False,
+                                    # vmin=0,
+                                    vmax=threshold,
+                                    threshold=0)
+        fig_name = join(output_folder, '{}_interactive.html'.format(map))
+        html_view.save_as_html(fig_name)
+        
+    # plot a simple thresholded image
+    normal_view = nilplot.plot_img(img=img,
+                                bg_img=brain,
+                                cut_coords=coords,
+                                cmap=cm.gray,
+                                vmax=threshold,
+                                vmin=0,
+                                colorbar=True)
+    fig_name = join(output_folder, '{}_plot.pdf'.format(map))
+    normal_view.savefig(fig_name)
+    normal_view.close()
+
+# only one of do_normalise_before and do_normalise_after should be True
+# both can be False
+def t2_pipeline(do_coreg=True, do_normalise_before=False,
+                do_segment=True, do_normalise_after=False, do_plot=True,
+                keep_tmp=True, sub_name='sub-11', sess_num='ses-17',
+                root_path='/neurospin/ibc'):
+
+    DATA_LOC = join(root_path, 'sourcedata', sub_name, sess_num)
+    SAVE_TO = join(root_path, 'derivatives', sub_name, sess_num)
+
+    if do_normalise_before or do_normalise_after:
+        space = "MNI152"
+    else:
+        space = "individual"
+
+    if not exists(SAVE_TO):
+        makedirs(SAVE_TO)
+
+    start_time = time.time()
+
+    # data files
+    data_dir = DATA_LOC
+
+    niftis = []
+    jsons = []
+    for fi in listdir(join(data_dir, 'anat')):
+        if fi.split('_')[-1] == 'T2map.nii.gz':
+            niftis.append(join(data_dir, 'anat', fi))
+        elif fi.split('_')[-1] == 'T2map.json':
+            jsons.append(join(data_dir, 'anat', fi))
+        else:
+            continue
+    niftis.sort()
+    jsons.sort()
+
+    run_count = 0
+    for nifti in niftis:
+        # preprocessing directory setup
+        time_elapsed = time.time() - start_time
+        print('[INFO,  t={:.2f}s] copying necessary files...'.format(time_elapsed))
+        cwd = SAVE_TO
+        preproc_dir = join(cwd, 'tmp_t2', 'preproc')
+        if not exists(preproc_dir):
+            makedirs(preproc_dir)
+
+        system('cp {} {}'.format(nifti, preproc_dir))
+        nifti = join(preproc_dir, nifti.split(sep)[-1])
+        system('gunzip -df {}'.format(nifti))
+        nifti = join(preproc_dir, nifti.split(sep)[-1].split('.')[0] + '.nii')
+
+        if do_coreg:
+            # t1 image as an anatomical image
+            t1_niftis = []
+            for fi in listdir(join(data_dir, 'anat')):
+                if fi.split('_')[-1] == 'T1map.nii.gz':
+                    t1_niftis.append(join(data_dir, 'anat', fi))
+            t1_niftis.sort()
+            t1_nifti = t1_niftis[-1]
+            system('cp {} {}'.format(t1_nifti, preproc_dir))
+            t1_nifti = join(preproc_dir, t1_nifti.split(sep)[-1])
+            system('gunzip -df {}'.format(t1_nifti))
+            t1_nifti = join(preproc_dir, t1_nifti.split(sep)[-1].split('.')[0] + '.nii')
+
+        # preprocessing step: spatial normalization to MNI space
+        # of T1 maps
+        if do_normalise_before:
+            image = nifti
+            if do_coreg:
+                t1_img = t1_nifti
+                time_elapsed = time.time() - start_time
+                print('[INFO,  t={:.2f}s] segmenting the t1 image'.format(time_elapsed))
+                out_info = segment(t1_img, False)
+                time_elapsed = time.time() - start_time
+                print('[INFO,  t={:.2f}s] transforming images to MNI space...'.format(time_elapsed))
+                out_info = to_MNI(image=t1_img, data=out_info, func=image)
+                normed_t1_img = out_info['anat']
+                normed_nifti = out_info['func'][0]
+            else:
+                time_elapsed = time.time() - start_time
+                print('[INFO,  t={:.2f}s] segmenting the t2 image'.format(time_elapsed))
+                out_info = segment(image, False)
+                time_elapsed = time.time() - start_time
+                print('[INFO,  t={:.2f}s] transforming images to MNI space...'.format(time_elapsed))
+                out_info = to_MNI(image, data=out_info)
+                normed_nifti = out_info['anat']
+            time_elapsed = time.time() - start_time
+            print('[INFO,  t={:.2f}s] \t transformed {}'.format(time_elapsed, nifti.split(sep)[-1]))
+
+        # preprocessing step: transform t1 image to t2 space
+        if do_coreg:
+            time_elapsed = time.time() - start_time
+            print('[INFO,  t={:.2f}s] transforming t1 image to t2 space...'.format(time_elapsed))
+            if do_normalise_before:
+                t2_img = normed_nifti
+                t1_img = normed_t1_img
+            else:
+                t2_img = nifti
+                t1_img = t1_nifti
+            mean_t2 = mean_img(t2_img)
+            mean_t2_img = join(preproc_dir, 'mean_{}'.format(t2_img.split(sep)[-1]))
+            mean_t2.to_filename(mean_t2_img)
+            out_info = to_T2space(t2_img=mean_t2_img, t1_img=t1_img, output_dir=preproc_dir)
+            print('[INFO,  t={:.2f}s] \t transformed {} to {} space'.format(time_elapsed,
+                    t1_img.split(sep)[-1], mean_t2_img.split(sep)[-1]))
+
+
+        # preprocessing step: segmenting largest flip angle image
+        if do_segment:
+            if do_normalise_before:
+                time_elapsed = time.time() - start_time
+                print('[INFO,  t={:.2f}s] creating a mask'.format(time_elapsed))
+                if do_coreg:
+                    image = normed_t1_img
+                else:
+                    image = normed_nifti
+                mni = compute_brain_mask(image)
+                closed_mni = closing(mni, 12)
+                union = intersect_masks([mni, closed_mni], threshold=0)
+            else:
+                if do_coreg:
+                    image = t1_img
+                else:
+                    image = nifti
+                time_elapsed = time.time() - start_time
+                print('[INFO,  t={:.2f}s] segmenting the image for creating a mask'.format(time_elapsed))
+                out_info = segment(image, False)
+                segments = [out_info['gm'], out_info['wm']]
+                time_elapsed = time.time() - start_time
+                print('[INFO,  t={:.2f}s] \t segmented {}'.format(time_elapsed, image.split(sep)[-1]))
+
+                # preprocessing step: creating a mask
+                time_elapsed = time.time() - start_time
+                print('[INFO,  t={:.2f}s] creating a mask using segments'.format(time_elapsed))
+                add = math_img("img1 + img2", img1=segments[0], img2=segments[1])
+                if sub_name=='sub-08':
+                    full = compute_epi_mask(add, exclude_zeros=True)
+                else:
+                    full = compute_epi_mask(add)
+                insides = compute_background_mask(full, opening=12)
+                union = intersect_masks([full, insides], threshold=0)
+
+            mask_file = join(preproc_dir,'mask.nii')
+            union.to_filename(mask_file)
+
+            if do_coreg:
+                resampled_mask = resample_to_img(mask_file, mean_t2_img, clip=True)
+                rounded_resampled_mask = math_img('np.around(img1)', img1=resampled_mask)
+                resampled_mask_img = join(preproc_dir, 'resampled_mask.nii')
+                rounded_resampled_mask.to_filename(resampled_mask_img)
+            else:
+                resampled_mask_img = mask_file
+
+
+        # estimation directory setup
+        time_elapsed = time.time() - start_time
+        print('[INFO,  t={:.2f}s] starting estimation...'.format(time_elapsed))
+        recon_dir = join(cwd, 'tmp_t2', 'recon')
+        if not exists(recon_dir):
+            makedirs(recon_dir)
+
+        if do_normalise_before:
+            niftis_str = normed_nifti
+        else:
+            niftis_str = nifti
+
+        if do_segment == False:
+            mask_file = None
+
+
+        # estimation: t2 estimation
+        system(f"python3 ../scripts/qmri_t2_map.py\
+            -v 1\
+            -s {sub_name}\
+            -o {recon_dir}\
+            -n {niftis_str}\
+            -m {resampled_mask_img}")
+
+        recon_map = join(recon_dir, f'{sub_name}_T2map.nii.gz')
+
+        # postprocessing: normalization of reconstructed t1 map
+        if do_normalise_after:
+            postproc_dir = join(cwd, 'tmp_t2', 'postproc')
+            if not exists(postproc_dir):
+                makedirs(postproc_dir)
+            
+            system('cp {} {}'.format(recon_map, postproc_dir))
+            time_elapsed = time.time() - start_time
+            print('[INFO,  t={:.2f}s] normalizing reconstructed map...'.format(time_elapsed))
+            image = join(postproc_dir, f'{sub_name}_T2map.nii.gz')
+            system('gunzip -df {}'.format(image))
+            image = join(postproc_dir, f'{sub_name}_T2map.nii')
+            out_info = to_MNI(image, segmented=out_info.nipype_results['segment'])
+            norm_recon_map = out_info['anat']
+
+
+        # doing the plots
+        if do_plot:
+            time_elapsed = time.time() - start_time
+            print('\n[INFO,  t={:.2f}s] plotting the map...'.format(time_elapsed))
+            plot_dir = join(cwd, 'tmp_t2', 'plot')
+            if not exists(plot_dir):
+                makedirs(plot_dir)
+            if do_normalise_after:
+                t2_img = norm_recon_map
+            else:
+                t2_img = recon_map
+            plot_thresholded_qmap(img=t2_img,
+                                thresh="95",
+                                map=f"{sub_name}_T2map",
+                                interactive=True,
+                                coords=(10,56,43),
+                                output_folder=plot_dir)
+
+        time_elapsed = time.time() - start_time
+        print('\n[INFO,  t={:.2f}s] DONE'.format(time_elapsed))
+
+
+        # move derived files out and delete tmp_t2 directory
+        final_recon_map = join(SAVE_TO, f'{sub_name}_run-0{run_count+1}_space-{space}_T2map.nii.gz')
+        if do_normalise_after:
+            system('gzip {}'.format(norm_recon_map))
+            recon_map = norm_recon_map + '.gz'
+        shutil.move(recon_map, final_recon_map)
+
+        if do_plot:
+            for fi in listdir(plot_dir):
+                plot_name = join(plot_dir, fi)
+                final_plot_name = join(SAVE_TO, final_recon_map.split(sep)[-1].split('.')[0]
+                                        + '_' + fi.split('_')[-1])
+                shutil.move(plot_name, final_plot_name)
+
+        if not keep_tmp:
+            shutil.rmtree(join(SAVE_TO, 'tmp_t2'))
+
+        time_elapsed = time.time() - start_time
+        print('\n[INFO,  t={:.2f}s] created {} \n\n'.format(time_elapsed, final_recon_map))
+        run_count = run_count + 1
+
+
+
+# only one of do_normalise_before and do_normalise_after should be True
+# both can be False
+def t1_pipeline(do_normalise_before=False,
+                do_segment=True, do_normalise_after=False,
+                do_plot=True,  keep_tmp=True ,
+                sub_name='sub-11', sess_num='ses-17', 
+                root_path='/neurospin/ibc'):
+
+    DATA_LOC = join(root_path, 'sourcedata', sub_name, sess_num)
+    SAVE_TO = join(root_path, 'derivatives', sub_name, sess_num)
+
+    if do_normalise_before or do_normalise_after:
+        space = "MNI152"
+    else:
+        space = "individual"
+
+    if not exists(SAVE_TO):
+        makedirs(SAVE_TO)
+
+    start_time = time.time()
+
+    # data files
+    data_dir = DATA_LOC
+
+    niftis = []
+    jsons = []
+    for fi in listdir(join(data_dir, 'anat')):
+        if fi.split('_')[-1] == 'T1map.nii.gz':
+            niftis.append(join(data_dir, 'anat', fi))
+        elif fi.split('_')[-1] == 'T1map.json':
+            jsons.append(join(data_dir, 'anat', fi))
+        elif fi.split('_')[-1] == 'B1map.nii.gz':
+            b1_map_nifti = join(data_dir, 'anat', fi)
+        elif fi.split('_')[-1] == 'B1map.json':
+            b1_map_json = join(data_dir, 'anat', fi)
+        else:
+            continue
+    niftis.sort()
+    jsons.sort()
+
+
+    # preprocessing directory setup
+    time_elapsed = time.time() - start_time
+    print('[INFO,  t={:.2f}s] copying necessary files...'.format(time_elapsed))
+    cwd = SAVE_TO
+    preproc_dir = join(cwd, 'tmp_t1', 'preproc')
+    if not exists(preproc_dir):
+        makedirs(preproc_dir)
+
+    # copy data files to tmp_t1 directory
+    cnt = 0
+    for nii, json in zip(niftis, jsons):
+        system('cp {} {}'.format(nii, preproc_dir))
+        niftis[cnt] = join(preproc_dir, nii.split(sep)[-1])
+        system('gunzip -df {}'.format(niftis[cnt]))
+        niftis[cnt] = join(preproc_dir, nii.split(sep)[-1].split('.')[0] + '.nii')
+        system('cp {} {}'.format(json, preproc_dir))
+        jsons[cnt] = join(preproc_dir, json.split(sep)[-1])
+        cnt += 1
+    system('cp {} {}'.format(b1_map_nifti, preproc_dir))
+    b1_map_nifti = join(preproc_dir, b1_map_nifti.split(sep)[-1])
+    system('gunzip -df {}'.format(b1_map_nifti))
+    b1_map_nifti = join(preproc_dir, b1_map_nifti.split(sep)[-1].split('.')[0] + '.nii')
+    system('cp {} {}'.format(b1_map_json, preproc_dir))
+    b1_map_json = join(preproc_dir, b1_map_json.split(sep)[-1])
+
+
+    # preprocessing step: spatial normalization to MNI space
+    # of T1 maps
+    if do_normalise_before:
+        time_elapsed = time.time() - start_time
+        print('[INFO,  t={:.2f}s] segmenting highest flip angle image'.format(time_elapsed))
+        image = niftis[-1]
+        out_info = segment(image, True)
+        # save normalised segments
+        segments = [join(preproc_dir, f"w{out_info[segment].split('/')[-1]}") for segment in ['gm', 'wm']]
+        time_elapsed = time.time() - start_time
+        print('[INFO,  t={:.2f}s] transforming images to MNI space...'.format(time_elapsed))
+        normed_niftis = []
+        cnt = 0
+        for nii in niftis:
+            image = nii
+            if cnt == len(niftis)-1:
+                b1_map = b1_map_nifti
+                out_info = to_MNI(image, data=out_info, func=b1_map)
+                normed_b1_map = out_info['func'][0]
+            else:
+                out_info = to_MNI(image, data=out_info)
+            normed_niftis.append(out_info['anat'])
+            time_elapsed = time.time() - start_time
+            print('[INFO,  t={:.2f}s] \t transformed {}'.format(time_elapsed, nii.split(sep)[-1]))
+            cnt = cnt + 1
+
+    # preprocessing step: segmenting largest flip angle image
+    if do_segment:
+        time_elapsed = time.time() - start_time
+        if do_normalise_before:
+            print('[INFO,  t={:.2f}s] creating a mask'.format(time_elapsed))
+            image = normed_niftis[-1]
+            mni = compute_brain_mask(image)
+            closed_mni = closing(mni, 12)
+            union = intersect_masks([mni, closed_mni], threshold=0)
+        else:
+            print('[INFO,  t={:.2f}s] segmenting highest flip angle image'.format(time_elapsed))
+            image = niftis[-1]
+            out_info = segment(image, True)
+            segments = [out_info['gm'], out_info['wm']]
+            time_elapsed = time.time() - start_time
+            print('[INFO,  t={:.2f}s] \t segmented {}'.format(time_elapsed, image.split(sep)[-1]))
+
+            # preprocessing step: creating a mask
+            print('[INFO,  t={:.2f}s] creating a mask using segments'.format(time_elapsed))
+            add = math_img("img1 + img2", img1=segments[0], img2=segments[1])
+            if sub_name=='sub-08':
+                full = compute_epi_mask(add, exclude_zeros=True)
+            else:
+                full = compute_epi_mask(add)
+            insides = compute_background_mask(full, opening=12)
+            union = intersect_masks([full, insides], threshold=0)
+
+        mask_file = join(preproc_dir, 'mask.nii')
+        union.to_filename(mask_file)
+
+
+    # estimation directory setup
+    time_elapsed = time.time() - start_time
+    print('[INFO,  t={:.2f}s] starting estimation...'.format(time_elapsed))
+    recon_dir = join(cwd, 'tmp_t1', 'recon')
+    if not exists(recon_dir):
+        makedirs(recon_dir)
+    jsons_str = ' '.join(jsons)
+
+    if do_normalise_before:
+        niftis_str = ' '.join(normed_niftis)
+        b1_map_str = normed_b1_map
+    else:
+        niftis_str = ' '.join(niftis)
+        b1_map_str = b1_map_nifti
+
+    if do_segment == False:
+        mask_file = None
+
+    # estimation: parameter extraction
+    system(f"python3 ../scripts/qmri_t1_map_b1_params.py\
+        -v 1\
+        -s {sub_name}\
+        -o {recon_dir}\
+        -g {jsons_str}\
+        -b {b1_map_json}")
+
+    # estimation: t1 estimation
+    system(f"python3 ../scripts/qmri_t1_map_b1.py\
+        -v 1\
+        -s {sub_name}\
+        -o {recon_dir}\
+        -g {niftis_str}\
+        -b {b1_map_str}\
+        -r {join(recon_dir,f'{sub_name}_t1_map_b1.json')}\
+        -d fit\
+        -m {mask_file}")
+
+    recon_map = join(recon_dir, f'{sub_name}_T1map.nii.gz')
+
+    # postprocessing: normalization of reconstructed t1 map
+    if do_normalise_after:
+        postproc_dir = join(cwd, 'tmp_t1', 'postproc')
+        if not exists(postproc_dir):
+            makedirs(postproc_dir)
+        recon_map = join(recon_dir, f'{sub_name}_T1map.nii.gz')
+        system('cp {} {}'.format(recon_map, postproc_dir))
+        time_elapsed = time.time() - start_time
+        print('[INFO,  t={:.2f}s] normalizing reconstructed t1 map...'.format(time_elapsed))
+        image = join(postproc_dir, f'{sub_name}_T1map.nii.gz')
+        system('gunzip -df {}'.format(image))
+        image = join(postproc_dir, f'{sub_name}_T1map.nii')
+        out_info = to_MNI(image, segmented=out_info.nipype_results['segment'])
+        norm_recon_map = out_info['anat']
+
+
+    # doing the plots
+    if do_plot:
+        time_elapsed = time.time() - start_time
+        print('\n[INFO,  t={:.2f}s] plotting the map...'.format(time_elapsed))
+        plot_dir = join(cwd, 'tmp_t1', 'plot')
+        if not exists(plot_dir):
+            makedirs(plot_dir)
+        if do_normalise_after:
+            t1_img = norm_recon_map
+        else:
+            t1_img = join(recon_dir, f'{sub_name}_T1map.nii.gz')
+        plot_thresholded_qmap(img=t1_img,
+                            thresh="99",
+                            map=f"{sub_name}_T1map_fit",
+                            interactive=True,
+                            coords=(10,56,43),
+                            output_folder=plot_dir)
+
+    time_elapsed = time.time() - start_time
+    print('\n[INFO,  t={:.2f}s] DONE'.format(time_elapsed))
+
+    # move derived files out and delete tmp_t1 directory
+    final_recon_map = join(SAVE_TO, f'{sub_name}_space-{space}_T1map.nii.gz')
+    if do_normalise_after:
+        system('gzip {}'.format(norm_recon_map))
+        recon_map = norm_recon_map + '.gz'
+    shutil.move(recon_map, final_recon_map)
+
+    if do_plot:
+        for fi in listdir(plot_dir):
+            plot_name = join(plot_dir, fi)
+            final_plot_name = join(SAVE_TO, final_recon_map.split(sep)[-1].split('.')[0]
+                                    + '_' + fi.split('_')[-1])
+            shutil.move(plot_name, final_plot_name)
+
+    if not keep_tmp:
+        shutil.rmtree(join(SAVE_TO, 'tmp_t1'))
+
+    time_elapsed = time.time() - start_time
+    print('\n[INFO,  t={:.2f}s] created {} \n\n'.format(time_elapsed, final_recon_map))

--- a/scripts/qmri_README.md
+++ b/scripts/qmri_README.md
@@ -1,0 +1,63 @@
+## Get it working:
+
+* Install some of the dependencies as follows:
+     
+        pip3 install nilearn nibabel matplotlib numpy joblib dicom progressbar Cython
+
+* Install `qmri` from bioproj (requires CEA login) as follows:
+
+        git clone -b ibc_changes https://bioproj.extra.cea.fr/git/qmri
+        cd qmri
+        python3 setup.py build_ext
+        python3 setup.py install
+
+* Install `pypreprocess` by following the instructions given [here](https://github.com/neurospin/pypreprocess)
+
+* After installing all the dependencies, to run, simply do:
+    
+        python3 qmri_run_estimation.py
+
+## qMRI preprocessing and estimation pipeline:
+
+* `qmri_run_estimation.py` runs 4 variations of preprocessing and qmri-estimation pipelines on all 12 IBC subjects for which the data is available:
+    
+    * T2 estimation on qmri images in subject-space
+    * T2 estimation on qmri images in MNI-space
+    * T1 estimation on qmri images in subject-space
+    * T1 estimation on qmri images in MNI-space
+
+* `qmri_run_estimation.py` imports from `ibc_public/util_relaxo.py` containing preprocessing steps for qmri images that happen before estimation, run the estimation itself (explained in next point), and plot the final estimated maps:
+
+    * all preprocessing is done using `pypreprocess`
+
+    * function `t1_pipeline`:
+
+        1. checks whether sourcedata is defaced (by looking for "Deface: True" field in .json sidecars) - if not, defaces it using `pydeface`
+        2. copies and extracts t1 images from sourcedata in a tmp directory
+        3. checks whether to return maps in MNI or subject-space:
+            * if `do_normalise_before` is set to True, segments highest flip angle image and uses the segments to run spatial normalisation and transforms the raw images to MNI space and then computes mask in MNI space
+            * if `do_normalise_before` is set to False, segments highest flip angle image and uses the segments to compute a mask in subject-space to remove the skull
+        4. extracts relevant acquisition parameters from .json sidecar (by running `scripts/qmri_t1_map_b1_params.py`)
+        5. runs qmri t1 estimation pipeline (`scripts/qmri_t1_map_b1.py`)
+        6. thresholds voxel intensity at 99 percentile and plots the estimated maps.
+
+    * function `t2_pipeline`:
+
+        1. checks whether sourcedata is defaced (by looking for "Deface: True" field in .json sidecars) - if not, defaces it using `pydeface`
+        2. copies and extracts t2 images from sourcedata in a tmp directory
+        3. since t2 maps are low resolution, also copies highest flip-angle t1 image for better masking
+        3. checks whether to return maps in MNI or subject-space:
+            * if `do_normalise_before` is set to True, segments the t1 image and uses the segments to run spatial normalisation to transform the raw t1 and t2 images to MNI space and then use the high res t1 image to compute mask in MNI-space
+            * if `do_normalise_before` is set to False, corregisters the t1 image to t2 image and uses the high res corregistered t1 image to compute a mask in subject-space
+        4. runs qmri t2 estimation pipeline (`scripts/t2_map.py`)
+        6. thresholds voxel intensity at 95 percentile and plots the estimated maps.
+
+* Package [`qmri`](https://bioproj.extra.cea.fr/git/qmri), hosted on bioproj, is used for T1 and T2 map estimation.
+
+    * `scripts/qmri_t1_map_b1.py` (for T1 estimation) and `scripts/qmri_t2_map.py` (for T2 estimation) are the scripts containing estimation pipelines using `qmri`.
+
+## Author:
+
+Himanshu Aggarwal 
+himanshu.aggarwal@inria.fr
+2021-22

--- a/scripts/qmri_run_estimation.py
+++ b/scripts/qmri_run_estimation.py
@@ -1,0 +1,38 @@
+from ibc_public.utils_relaxo import t1_pipeline
+from ibc_public.utils_relaxo import t2_pipeline
+from joblib import Parallel, delayed
+
+
+def run_all_estimation(sub, sess, data_root_path):
+    # T2 estimation in subject space
+    print('Running t2-est without spat. norm. for {}'.format(sub))
+    t2_pipeline(sub_name=sub, sess_num=sess, do_plot=False, keep_tmp=False,
+                root_path=data_root_path)
+
+    # T2 estimation in MNI space
+    print('Running t2-est with spat. norm. for {}'.format(sub))
+    t2_pipeline(do_normalise_before=True, sub_name=sub, sess_num=sess,
+                do_plot=False, keep_tmp=False, root_path=data_root_path)
+
+    # T1 estimation in subject space
+    print('Running t1-est without spat. norm. for {}'.format(sub))
+    t1_pipeline(sub_name=sub, sess_num=sess, do_plot=False, keep_tmp=False,
+                root_path=data_root_path)
+
+    # T1 estimation in MNI space
+    print('Running t1-est with spat. norm. for {}'.format(sub))
+    t1_pipeline(do_normalise_before=True, sub_name=sub, sess_num=sess,
+                do_plot=False, keep_tmp=False, root_path=data_root_path)
+
+
+if __name__ == "__main__":
+
+    DATA_ROOT = '/neurospin/ibc'
+
+    sub_sess = {'sub-01': 'ses-21', 'sub-04': 'ses-20', 'sub-05': 'ses-22',
+    'sub-06': 'ses-20', 'sub-07': 'ses-20', 'sub-08': 'ses-35',
+    'sub-09': 'ses-19', 'sub-11': 'ses-17', 'sub-12': 'ses-17',
+    'sub-13': 'ses-20', 'sub-14': 'ses-20', 'sub-15': 'ses-18'}
+
+    Parallel(n_jobs=1)(delayed(run_all_estimation)(sub, sess, DATA_ROOT) for sub,
+                    sess in sub_sess.items())

--- a/scripts/qmri_run_estimation.py
+++ b/scripts/qmri_run_estimation.py
@@ -1,8 +1,16 @@
+"""
+Author: Himanshu Aggarwal (himanshu.aggarwal@inria.fr), 2021-22
+"""
+
 from ibc_public.utils_relaxo import (t1_pipeline, t2_pipeline)
 from joblib import Parallel, delayed
 
 
 def run_all_estimation(sub, sess, data_root_path):
+    """
+    Run t2 and t1 preproc and estimation pipelines, 
+    to return maps in subject-space and in MNI-152 space 
+    """
     # T2 estimation in subject space
     print('Running t2-est without spat. norm. for {}'.format(sub))
     t2_pipeline(sub_name=sub, sess_num=sess, do_plot=False, keep_tmp=False,
@@ -26,8 +34,10 @@ def run_all_estimation(sub, sess, data_root_path):
 
 if __name__ == "__main__":
 
+    # root location of sourcedata and derivatives
     DATA_ROOT = '/neurospin/ibc'
 
+    # relaxometry session numbers for each subject
     sub_sess = {'sub-01': 'ses-21', 'sub-04': 'ses-20', 'sub-05': 'ses-22',
     'sub-06': 'ses-20', 'sub-07': 'ses-20', 'sub-08': 'ses-35',
     'sub-09': 'ses-19', 'sub-11': 'ses-17', 'sub-12': 'ses-17',

--- a/scripts/qmri_run_estimation.py
+++ b/scripts/qmri_run_estimation.py
@@ -1,5 +1,4 @@
-from ibc_public.utils_relaxo import t1_pipeline
-from ibc_public.utils_relaxo import t2_pipeline
+from ibc_public.utils_relaxo import (t1_pipeline, t2_pipeline)
 from joblib import Parallel, delayed
 
 

--- a/scripts/qmri_t1_map_b1.py
+++ b/scripts/qmri_t1_map_b1.py
@@ -1,0 +1,232 @@
+##########################################################################
+# NSAp - Copyright (C) CEA, 2016 - 2021
+# Distributed under the terms of the CeCILL-B license, as published by
+# the CEA-CNRS-INRIA. Refer to the LICENSE file or to
+# http://www.cecill.info/licences/Licence_CeCILL-B_V1-en.html
+# for details.
+##########################################################################
+
+# Sytem import
+import argparse
+import os
+import nibabel
+import math
+import json
+import numpy as np
+
+# Qmri import
+from qmri.t1.t1_io import load_sequence
+from qmri.t1.t1_io import save_sequence
+from qmri.t1.interpolation import resample_image
+from qmri.t1.despot1 import QuantitativeT1Reconstruction
+
+
+
+# Script documentation
+doc = """
+T1 map reconstruction
+~~~~~~~~~~~~~~~~~~~~~
+
+Reconstruct the T1 map from a B1 image and N GRE images acquired at different
+flip angles.
+Two reconstruction methods are available:
+
+* 'analytic': an analytic method, only available for 2 flip angles (fast).
+* 'fit': a joint T1, M0 fit (slower but better).
+
+Record Json files, following the bids (http://bids.neuroimaging.io/) standard,
+are expected to describe the B1 and GRE sequences.
+The files must specified the flip angles and repetiton times of both sequences.
+
+::
+
+{
+    <subject_code_in_study>: {
+        <B1>: {
+            "FlipAngle": <flip_angle>,
+            "RepetitonTime": <repetiton_time>
+        },
+        <GRE>: {
+            "FlipAngle": <flip_angles>,
+            "RepetitonTime": <repetiton_times>
+        }
+    }
+}
+
+This file can be generated automatically using the 'qmri_t1_map_b1_parameters'
+command.
+"""
+
+def is_file(filearg):
+    """ Type for argparse - checks that file exists but does not open.
+    """
+    if not os.path.isfile(filearg):
+        raise argparse.ArgumentError(
+            "The file '{0}' does not exist!".format(filearg))
+    return filearg
+
+
+def is_directory(dirarg):
+    """ Type for argparse - checks that directory exists.
+    """
+    if not os.path.isdir(dirarg):
+        raise argparse.ArgumentError(
+            "The directory '{0}' does not exist!".format(dirarg))
+    return dirarg
+
+
+parser = argparse.ArgumentParser(description=doc)
+parser.add_argument(
+    "-v", "--verbose", dest="verbose", type=int, choices=[0, 1], default=0,
+    help="increase the verbosity level: 0 silent, 1 verbose.")
+parser.add_argument(
+    "-s", "--subjectid", dest="subjectid", required=True,
+    help="the subject code in study.")
+parser.add_argument(
+    "-o", "--outdir", dest="outdir", required=True, metavar="PATH",
+    help="the reconstruction directory.", type=is_directory)
+parser.add_argument(
+    "-g", "--niigres", dest="niigres", nargs="+", required=True,
+    help="the gre nifti images.", type=is_file)
+parser.add_argument(
+    "-b", "--niib1", dest="niib1", metavar="FILE", required=True,
+    help="the flip angle map (1/10degrees).", type=is_file)
+parser.add_argument(
+    "-r", "--record", dest="record", metavar="FILE", required=True,
+    help="a record containing the B1 and GRE sequence parameters.",
+    type=is_file)
+parser.add_argument(
+    "-d", "--method", dest="method", choices=("analytic", "fit"),
+    help="the reconstruction method.")
+parser.add_argument(
+    "-m", "--mask", dest="mask", metavar="FILE",
+    help=("if activated generate a mask with FSL BET that is applied on the "
+          "T1 map."))
+parser.add_argument(
+    "-t", "--thresh", dest="thresh", default=0.5, type=float,
+    help="fractional intensity threshold (0->1), smaller values give larger "
+    "brain outline estimates.")
+parser.add_argument(
+    "-k", "--spoiling-correction", action="store_true",
+    help="if set, perform a T1 spoiling correction.")
+parser.add_argument(
+    "-a", "--average-t2", type=float, default=85.5,
+    help="the average T2 value in ms.")
+
+args = parser.parse_args()
+
+
+"""
+Welcome message and checks.
+"""
+verbose = args.verbose
+if verbose > 0:
+    print("[INFO] Starting T1 map computation...")
+b1niifile = args.niib1
+greniifiles = args.niigres
+recordfile = args.record
+method = args.method
+mask_file = args.mask
+subjectid = args.subjectid
+working_dir = args.outdir
+spoiling_correction = args.spoiling_correction
+average_t2 = args.average_t2
+if verbose > 0:
+    print("[INFO] b1nii: '{0}'.".format(b1niifile))
+    print("[INFO] greniis: '{0}'.".format(greniifiles))
+    print("[INFO] record: '{0}'.".format(recordfile))
+    print("[INFO] method: '{0}'.".format(method))
+    print("[INFO] spoiling correction: {0}.".format(spoiling_correction))
+    print("[INFO] average t2 for spoiling correction: '{0}'.".format(average_t2))
+    print("[INFO] working directory: '{0}'.".format(working_dir))
+with open(recordfile) as open_file:
+    record = json.load(open_file)
+if (len(greniifiles) != len(record[subjectid]["GRE"]["FlipAngle"]) or
+        len(greniifiles) != len(record[subjectid]["GRE"]["RepetitionTime"])):
+    raise ValueError("Can't find GRE images meta information.")
+if (not isinstance(record[subjectid]["B1"]["FlipAngle"], float) or
+        not isinstance(record[subjectid]["B1"]["RepetitionTime"], float)):
+    raise ValueError("Can't find B1 images meta information.")
+
+
+"""
+Load sequences.
+"""
+b1array, b1affine = load_sequence(b1niifile)
+b1fa = record[subjectid]["B1"]["FlipAngle"]
+b1tr = record[subjectid]["B1"]["RepetitionTime"]
+gre_sequences = []
+grefas = record[subjectid]["GRE"]["FlipAngle"]
+gretrs = record[subjectid]["GRE"]["RepetitionTime"]
+for fimage, fa, tr in zip(greniifiles, grefas, gretrs):
+        gre_sequences.append((load_sequence(fimage)[0], fa, tr))
+
+if verbose > 0:
+    print("[INFO] b1fa: {0}.".format(b1fa))
+    print("[INFO] b1tr: {0}.".format(b1tr))
+    print("[INFO] grefas: {0}.".format(grefas))
+    print("[INFO] gretrs: {0}.".format(gretrs))
+
+"""
+Get a relative measure of the flip angle spatial distribution
+centered at the therical acquisition flip angle.
+"""
+relative_b1array = b1array * math.pi / 1800 / math.radians(b1fa)
+relative_b1file = os.path.join(working_dir,
+                               "{0}_B1map.nii.gz".format(subjectid))
+save_sequence(relative_b1array, b1affine, relative_b1file)
+
+
+"""
+Resample the B1 image to match the GREs geometry using linear interpolation.
+"""
+resampled_b1file = os.path.join(
+    working_dir, "resampled_" + os.path.basename(relative_b1file))
+
+moving_b1array, moving_b1affine = load_sequence(relative_b1file)
+target_grearray, target_greaffine = load_sequence(greniifiles[0])
+resampled_b1array = resample_image(
+        moving_b1array, target_grearray, moving_b1affine, target_greaffine,
+        interp_order=1)
+save_sequence(resampled_b1array, target_greaffine, resampled_b1file)
+
+
+"""
+Calculate T1 map from DESPOT data unsing an analytic method or a fit.
+"""
+b1array, b1affine = load_sequence(resampled_b1file)
+maskarray, maskaffine = load_sequence(mask_file)
+t1_constructor = QuantitativeT1Reconstruction(
+    gre_sequences, None, None, None, None, None,  b1_map_array=b1array,
+    mask_array=maskarray, spoiling_correction=spoiling_correction,
+    average_t2=average_t2, outdir=working_dir)
+if method == "fit":
+    if len(gre_sequences) <= 2:
+        raise ValueError("Expect more than two flip angles to perform the fit "
+                         "method.")
+    t1array, m0array, foptarray = t1_constructor.get_m0_t1_maps()
+else:
+    if len(gre_sequences) != 2:
+        raise ValueError("Expect two flip angles to perform the analytic "
+                         "method.")
+    m0array, foptarray = (None, None)
+    t1array = t1_constructor.get_t1_map_analytic_2_point()
+wrongest_array = (np.isnan(t1array) | np.isinf(t1array)).astype(int)
+t1file = os.path.join(working_dir, "{0}_T1map.nii.gz".format(subjectid))
+wrongestfile = os.path.join(
+    working_dir, "{0}_wrongest_T1map.nii.gz".format(subjectid))
+m0file, foptfile = (None, None)
+save_sequence(t1array, b1affine, t1file)
+save_sequence(wrongest_array, b1affine, wrongestfile)
+if m0array is not None:
+    m0file = os.path.join(working_dir, "{0}_M0.nii.gz".format(subjectid))
+    save_sequence(m0array, b1affine, m0file)
+if foptarray is not None:
+    foptfile = os.path.join(working_dir, "{0}_fopt.nii.gz".format(subjectid))
+    save_sequence(foptarray, b1affine, foptfile)
+if verbose > 0:
+    print("[RESULT] t1: {0}".format(t1file))
+    print("[RESULT] wrongly estimated t1: {0}".format(wrongestfile))
+    print("[RESULT] m0: {0}".format(m0file)) 
+    print("[RESULT] fopt: {0}".format(foptfile)) 
+    

--- a/scripts/qmri_t1_map_b1_params.py
+++ b/scripts/qmri_t1_map_b1_params.py
@@ -1,0 +1,118 @@
+##########################################################################
+# NSAp - Copyright (C) CEA, 2016 - 2021
+# Distributed under the terms of the CeCILL-B license, as published by
+# the CEA-CNRS-INRIA. Refer to the LICENSE file or to
+# http://www.cecill.info/licences/Licence_CeCILL-B_V1-en.html
+# for details.
+##########################################################################
+
+# Sytem import
+import argparse
+import json
+import os
+
+# Qmri import
+from qmri.t1.t1_io import load_b1_sequence_parameters
+from qmri.t1.t1_io import load_gre_sequence_parameters
+
+
+# Script documentation
+doc = """
+T1 map reconstruction parameters
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Get the B1 and GRE sequences associated parameters. 
+"""
+
+def is_file(filearg):
+    """ Type for argparse - checks that file exists but does not open.
+    """
+    if not os.path.isfile(filearg):
+        raise argparse.ArgumentError(
+            "The file '{0}' does not exist!".format(filearg))
+    return filearg
+
+
+def is_directory(dirarg):
+    """ Type for argparse - checks that directory exists.
+    """
+    if not os.path.isdir(dirarg):
+        raise argparse.ArgumentError(
+            "The directory '{0}' does not exist!".format(dirarg))
+    return dirarg
+
+
+parser = argparse.ArgumentParser(description=doc)
+parser.add_argument(
+    "-v", "--verbose", dest="verbose", type=int, choices=[0, 1], default=0,
+    help="increase the verbosity level: 0 silent, 1 verbose.")
+parser.add_argument(
+    "-s", "--subjectid", dest="subjectid", required=True,
+    help="the subject code in study.")
+parser.add_argument(
+    "-o", "--outdir", dest="outdir", required=True, metavar="PATH",
+    help="the destination directory.", type=is_directory)
+parser.add_argument(
+    "-g", "--jsongres", dest="jsongres", nargs="+", required=True,
+    help="one json file of each GRE sequence.", type=is_file)
+parser.add_argument(
+    "-b", "--jsonb1", dest="jsonb1", metavar="FILE", required=True,
+    help="one json file of the b1 sequence.", type=is_file)
+args = parser.parse_args()
+
+
+"""
+Welcome message and checks
+"""
+verbose = args.verbose
+if verbose > 0:
+    print("[INFO] Starting B1 and GRE sequences parameters extraction...")
+b1jsonfile = args.jsonb1
+grejsonfiles = args.jsongres
+working_dir = args.outdir
+subjectid = args.subjectid
+if verbose > 0:
+    print("[INFO] b1jsonfile: '{0}'.".format(b1jsonfile))
+    print("[INFO] grejsonfiles: '{0}'.".format(grejsonfiles))
+    print("[INFO] working directory: '{0}'.".format(working_dir))
+
+
+"""
+Load sequences and sequences parameters
+"""
+b1fa, b1tr = load_b1_sequence_parameters(b1jsonfile)
+gre_sequences = []
+for fjson in grejsonfiles:
+    gre_sequences.append(load_gre_sequence_parameters(fjson))
+grefas = [x[0] for x in gre_sequences]
+gretrs = [x[1] for x in gre_sequences]
+if verbose > 0:
+    print("[INFO] b1fa: {0}.".format(b1fa))
+    print("[INFO] b1tr: {0}.".format(b1tr))
+    print("[INFO] grefas: {0}.".format(grefas))
+    print("[INFO] gretrs: {0}.".format(gretrs))
+
+
+"""
+Save the result following bids (http://bids.neuroimaging.io/) standard.
+"""
+record = {
+    subjectid: {
+        "B1": {
+            "FlipAngle": b1fa,
+            "RepetitionTime": b1tr
+        },
+        "GRE": {
+            "FlipAngle": grefas,
+            "RepetitionTime": gretrs
+        }
+    }
+}
+record_file = os.path.join(working_dir, "{0}_t1_map_b1.json".format(subjectid))
+with open(record_file, "wt") as open_file:
+    json.dump(record, open_file, indent=4)
+if verbose > 0:
+    print("[INFO] record: {0}.".format(record_file))
+
+
+

--- a/scripts/qmri_t2_map.py
+++ b/scripts/qmri_t2_map.py
@@ -1,0 +1,114 @@
+##########################################################################
+# NSAp - Copyright (C) CEA, 2016
+# Alexandre Vignaud - Yann Leprince
+# Distributed under the terms of the CeCILL-B license, as published by
+# the CEA-CNRS-INRIA. Refer to the LICENSE file or to
+# http://www.cecill.info/licences/Licence_CeCILL-B_V1-en.html
+# for details.
+##########################################################################
+
+# Sytem import
+from __future__ import print_function
+import argparse
+import os
+import numpy
+
+# Qmri import
+from qmri.t2.t2_io import get_serie_echo_times
+from qmri.t2.t2_io import load_sequence
+from qmri.t2.t2_io import save_sequence
+from qmri.t2.decay_fit import decay_fit
+
+
+# Script documentation
+doc = """
+T2 map reconstruction
+~~~~~~~~~~~~~~~~~~~~~
+
+Reconstruct the t2 map from a multi-constrast t2 relaxometry sequence.
+
+Command:
+
+python $HOME/git/qmri/qmri/scripts/t2_map \
+    -v 1 \
+    -s sub-11
+    -o /neurospin/tmp/agrigis/qmri/processed \
+    -n /neurospin/tmp/agrigis/qmri/data/s19.nii.gz \
+    -d /neurospin/tmp/agrigis/qmri/data/000019_relaxometry-T2-tra-2mm-multise-12contrastes \
+    -c /etc/fsl/5.0/fsl.sh \
+    -t 0.3 \
+    -m
+"""
+
+def is_file(filearg):
+    """ Type for argparse - checks that file exists but does not open.
+    """
+    if not os.path.isfile(filearg):
+        raise argparse.ArgumentError(
+            "The file '{0}' does not exist!".format(filearg))
+    return filearg
+
+
+def is_directory(dirarg):
+    """ Type for argparse - checks that directory exists.
+    """
+    if not os.path.isdir(dirarg):
+        raise argparse.ArgumentError(
+            "The directory '{0}' does not exist!".format(dirarg))
+    return dirarg
+
+
+parser = argparse.ArgumentParser(description=doc)
+parser.add_argument(
+    "-v", "--verbose", dest="verbose", type=int, choices=[0, 1], default=0,
+    help="increase the verbosity level: 0 silent, 1 verbose.")
+parser.add_argument(
+    "-s", "--subjectid", dest="subjectid", required=True,
+    help="the subject code in study.")
+parser.add_argument(
+    "-o", "--outdir", dest="outdir", required=True, metavar="PATH",
+    help="the reconstruction directory.", type=is_directory)
+parser.add_argument(
+    "-n", "--niirelaxo", dest="niirelaxo", metavar="FILE", required=True,
+    help="the relaxometry nifti image.", type=is_file)
+parser.add_argument(
+    "-m", "--mask", dest="mask", metavar="FILE",
+    help=("the mask file."))
+parser.add_argument(
+    "-t", "--thresh", dest="thresh", default=0.5, type=float,
+    help="fractional intensity threshold (0->1), smaller values give larger "
+    "brain outline estimates.")
+args = parser.parse_args()
+
+
+# Welcome message and checks
+verbose = args.verbose
+if verbose > 0:
+    print("[INFO] T2 map computation using the analytic method...")
+niirelaxo = args.niirelaxo
+subjectid = args.subjectid
+mask_file = args.mask
+if verbose > 0:
+    print("[INFO] niirelaxo: '{0}'.".format(niirelaxo))
+
+# Create the working directory
+working_dir = args.outdir
+if verbose > 0:
+    print("[INFO] Working directory: '{0}'.".format(working_dir))
+
+# Load sequence and sequence parameters
+echo_times = get_serie_echo_times(niirelaxo)
+relaxoarray, relaxoaffine = load_sequence(niirelaxo)
+if len(echo_times) != relaxoarray.shape[-1]:
+    raise Exception("Wrong echo number in '{0}'.".format(echo_times))
+teparms = []
+for key in sorted(echo_times.keys()):
+    teparms.append(echo_times[key])
+teparms = numpy.asarray(teparms)
+
+# Estimate the t2
+t2array = decay_fit(relaxoarray, teparms, maskfile=mask_file)
+t2file = os.path.join(working_dir, "{0}_T2map.nii.gz".format(subjectid))
+save_sequence(t2array, relaxoaffine, t2file)
+print("[INFO] t2file: '{0}'".format(t2file)) 
+    


### PR DESCRIPTION
* all preprocessing functions and t1 and t2 pipelines are in `ibc_public/utils_relaxo.py`
* all qmri package dependent estimation scripts are in `scripts/`
* `scripts/qmri_run_estimation.py` returns estimated t1 and t2-maps in both MNI and subject-space
* `scripts/qmri_README.md` contains details about all the pipelines