### PR TITLE
adding NARPS to main_contrasts file

### DIFF
--- a/ibc_data/main_contrasts.tsv
+++ b/ibc_data/main_contrasts.tsv
@@ -284,3 +284,11 @@ Scene	scene_possible_correct-scene_impossible_correct
 Scene	scene_correct-dot_correct
 Scene	dot_left-right
 Scene	dot_hard-easy
+NARPS	gain
+NARPS	loss
+NARPS	weakly_accept
+NARPS	weakly_reject
+NARPS	strongly_accept
+NARPS	strongly_reject
+NARPS	reject-accept
+NARPS	accept-reject


### PR DESCRIPTION
Hey @bthirion this is just the first attempt to modify the `main_contrasts.tsv` file with *NARPS* contrasts, in order to generate the maps as in using the scripts we already have (like the one you shared with me for the abstract).

For now I only included *NARPS* , since the contrasts are already defined in `utils_contrasts.py`, but that is not the case for *Visual Search*, which is the one next.

And I am also  unsure on how you make the difference between `main_contrasts.tsv` and `all_contrasts.tsv`, I mean, on how to select those to be included on the main file, so for now I included them all.

I hope I got what you meant when you suggested this PR, I am happy to discuss whenever feasible. Thank you! 