### PR TITLE
Correcting rsvp condition name

### DIFF
--- a/ibc_data/ibc_conditions.tsv
+++ b/ibc_data/ibc_conditions.tsv
@@ -52,7 +52,7 @@ HcpWm	0back_place	0-back, pictures of places were displayed
 HcpWm	2back_place	2-back, pictures of places were displayed
 RSVPLanguage	complex	Constituents, i.e. words formed syntactically and semantically congruent sentences with more than one clause grid image that may be tilted or not (high sentence-structure complexity)
 RSVPLanguage	simple	Constituents, i.e. words formed syntactically and semantically congruent sentences of one single clause (low_sentence-structure_complexity)
-RSVPLanguage	read_jabberwocky	Syntactically congruent sentences composed by non-lexical vocable constituents
+RSVPLanguage	jabberwocky	Syntactically congruent sentences composed by non-lexical vocable constituents
 RSVPLanguage	word_list	Syntactically non-congruent sentences but with semantic content
 RSVPLanguage	pseudoword_list	Syntactically and semantically non-congruent sentences composed by non-lexical vocable constituents
 RSVPLanguage	consonant_string	Syntactically and semantically non-congruent sentences composed by non-vocable constituents


### PR DESCRIPTION
Responding to #97.
Updating from `read_jabberwocky` to `jabberwocky` to match [contrast definition](https://github.com/individual-brain-charting/public_analysis_code/blob/ba49130a50c2178923bf0f464b0a38ba5de8a172/ibc_public/utils_contrasts.py#L2378).